### PR TITLE
Update README with link to usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The current maintainers (people who can merge pull requests) are:
 
 An up-to-date list of contributors is available here: https://github.com/scalamacros/scalamacros/graphs/contributors.
 
+### Documentation
+
+The usage docs are maintained with the main Scala docs here: http://docs.scala-lang.org/overviews/macros/overview.html
+
 ### Credits
 
 Over the years, many contributors influenced the design of Scala macros. Check out [Eugene Burmako's dissertation](https://infoscience.epfl.ch/record/226166?ln=en) for more information.


### PR DESCRIPTION
While trying to learn about scala macros I was directed to your github from the scalameta project.
I then had to search again on google to find documentation for using the macros. 
I found the stuff at http://docs.scala-lang.org/overviews/macros/overview.html I see you are the author but am not sure if these docs are up-to-date with your scalamacros github code.

Never-the-less I have created this pull request to put a link to the docs in your README. If the link is bad let me know the real link and I'll re-submit. 

Cheers

Karl