### PR TITLE
Implement syntax and structure for term name/select/apply/applytype/this

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,13 @@ to [ask for help](#getting-help).
 ## Setting up an IDE
 
 The project should import in IntelliJ as any normal sbt project.
-Autocompletion should work fine for the core modules.
-IntelliJ may report false red squiggly marks inside `macro` blocks, which will
-hopefully get fixed once the def macro syntax is stabilizes.
+The project does use advanced and experimental Scala features which
+causes IntelliJ to report false red squiggly marks in many places,
+for example
+- inside `macro` blocks
+- for pattern matches on the abstract trees, example `case Term.Name`
 
-I recommend to run the tests from the sbt console.
+Always compile/test from the sbt console.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,15 @@ I recommend to run the tests from the sbt console.
 ## Testing
 
 Tests are written using JUnit.
+It's best to start the sbt once and keep the same sbt shell running between
+test commands.
+The following commands assume you are inside the sbt shell
 
 ```sh
-$ sbt testsApi/test    # unit tests for public API
-$ sbt testsMacros/test # integration tests for macro expansions
+> testsApi/test    # unit tests for public API
+> testsMacros/test # integration tests for macro expansions
+> ++0.3.0-RC2      # switch scalaVersion to dotty
+> very test        # run all tests for all scalaVersion: 2.12, dotty, ...
 ```
 
 ## Opening pull requests

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ lazy val testsMacros = project
     noPublish,
     description := "Tests of new-style Scala macros",
     crossScalaVersions := List(scala212),
+    scalacOptions += "-language:experimental.macros",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
     scalacOptions ++= {

--- a/core/src/main/scala/scala/macros/internal/trees/TreeStructure.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeStructure.scala
@@ -6,8 +6,20 @@ import scala.macros.Universe
 
 trait TreeStructure { self: Universe =>
 
-  private[macros] implicit def treeStructure[T <: Tree]: Structure[T] = Structure { (p, tree) =>
+  private[macros] implicit def treeStructure[T <: Tree]: Structure[T] = new Structure[T] {
     // TODO: implement this
-    ???
+    override def render(p: Prettyprinter, x: T): Unit = x match {
+      case Lit.Char(ch) => p.raw("Lit.Char("); p.raw(x.syntax); p.raw(")")
+      case Lit.Double(d) => p.raw("Lit.Double("); p.raw(x.syntax); p.raw(")")
+      case Lit.Float(f) => p.raw("Lit.Float("); p.raw(x.syntax); p.raw(")")
+      case Lit.Int(l) => p.raw("Lit.Int("); p.raw(x.syntax); p.raw(")")
+      case Lit.Long(l) => p.raw("Lit.Long("); p.raw(x.syntax); p.raw(")")
+      case Lit.Null() => p.raw("Lit.Null()")
+      case Lit.String(str) => p.raw("Lit.String("); p.raw(x.syntax); p.raw(")")
+      case Lit.Symbol(sym) => p.raw("Lit.Symbol("); p.raw(x.syntax); p.raw(")")
+      case _ =>
+        pprint.log(x)
+        ???
+    }
   }
 }

--- a/core/src/main/scala/scala/macros/internal/trees/TreeStructure.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeStructure.scala
@@ -78,7 +78,7 @@ trait TreeStructure { self: Universe =>
         p.raw(x.syntax)
         p.raw(")")
       case _ =>
-        pprint.log(x)
+        println(s"NotImplementedYet: $x (${x.getClass})")
         ???
     }
   }

--- a/core/src/main/scala/scala/macros/internal/trees/TreeStructure.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeStructure.scala
@@ -9,14 +9,74 @@ trait TreeStructure { self: Universe =>
   private[macros] implicit def treeStructure[T <: Tree]: Structure[T] = new Structure[T] {
     // TODO: implement this
     override def render(p: Prettyprinter, x: T): Unit = x match {
-      case Lit.Char(ch) => p.raw("Lit.Char("); p.raw(x.syntax); p.raw(")")
-      case Lit.Double(d) => p.raw("Lit.Double("); p.raw(x.syntax); p.raw(")")
-      case Lit.Float(f) => p.raw("Lit.Float("); p.raw(x.syntax); p.raw(")")
-      case Lit.Int(l) => p.raw("Lit.Int("); p.raw(x.syntax); p.raw(")")
-      case Lit.Long(l) => p.raw("Lit.Long("); p.raw(x.syntax); p.raw(")")
+      case Term.This(qual) =>
+        p.raw("Term.This(")
+        render(p, qual.asInstanceOf[T])
+        p.raw(")")
+      case Term.Apply(fun, args) =>
+        p.raw("Term.Apply(")
+        render(p, fun.asInstanceOf[T])
+        p.raw(", ")
+        args match {
+          case Nil =>
+            p.raw("Nil")
+          case head :: tail =>
+            p.raw("List(")
+            render(p, head.asInstanceOf[T])
+            tail.foreach { arg =>
+              p.raw(", ")
+              render(p, arg.asInstanceOf[T])
+            }
+            p.raw(")")
+        }
+        p.raw(")")
+      case Term.Select(qual, name) =>
+        p.raw("Term.Select(")
+        render(p, qual.asInstanceOf[T])
+        p.raw(", ")
+        render(p, name.asInstanceOf[T])
+        p.raw(")")
+      case Name.Indeterminate(value) =>
+        p.raw("Name(\"")
+        p.raw(value)
+        p.raw("\")")
+      case Term.Name(value) =>
+        p.raw("Term.Name(\"")
+        p.raw(value)
+        p.raw("\")")
+      case Type.Name(value) =>
+        p.raw("Type.Name(\"")
+        p.raw(value)
+        p.raw("\")")
+      case Lit.Char(_) =>
+        p.raw("Lit.Char(")
+        p.raw(x.syntax)
+        p.raw(")")
+      case Lit.Double(_) =>
+        p.raw("Lit.Double(")
+        p.raw(x.syntax)
+        p.raw(")")
+      case Lit.Float(_) =>
+        p.raw("Lit.Float(")
+        p.raw(x.syntax)
+        p.raw(")")
+      case Lit.Int(_) =>
+        p.raw("Lit.Int(")
+        p.raw(x.syntax)
+        p.raw(")")
+      case Lit.Long(_) =>
+        p.raw("Lit.Long(")
+        p.raw(x.syntax)
+        p.raw(")")
       case Lit.Null() => p.raw("Lit.Null()")
-      case Lit.String(str) => p.raw("Lit.String("); p.raw(x.syntax); p.raw(")")
-      case Lit.Symbol(sym) => p.raw("Lit.Symbol("); p.raw(x.syntax); p.raw(")")
+      case Lit.String(_) =>
+        p.raw("Lit.String(")
+        p.raw(x.syntax)
+        p.raw(")")
+      case Lit.Symbol(_) =>
+        p.raw("Lit.Symbol(")
+        p.raw(x.syntax)
+        p.raw(")")
       case _ =>
         pprint.log(x)
         ???

--- a/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
@@ -9,8 +9,28 @@ trait TreeSyntax { self: Universe =>
   private[macros] implicit def treeSyntax[T <: Tree]: Syntax[T] = new Syntax[T] {
     override def render(p: Prettyprinter, x: T): Unit = x match {
       case Lit.Char(ch) => p.raw("'"); p.raw(ch.toString); p.raw("'")
-      case Lit.Double(d) => p.raw(d.toString); p.raw("d")
-      case Lit.Float(f) => p.raw(f.toString); p.raw("f")
+      case Lit.Double(n) =>
+        if (java.lang.Double.isNaN(n)) p.raw("Double.NaN")
+        else {
+          n match {
+            case Double.PositiveInfinity => p.raw("Double.PositiveInfinity")
+            case Double.NegativeInfinity => p.raw("Double.NegativeInfinity")
+            case _ =>
+              p.raw(n.toString)
+              p.raw("d")
+          }
+        }
+      case Lit.Float(n) =>
+        if (java.lang.Float.isNaN(n)) p.raw("Float.NaN")
+        else {
+          n match {
+            case Float.PositiveInfinity => p.raw("Float.PositiveInfinity")
+            case Float.NegativeInfinity => p.raw("Float.NegativeInfinity")
+            case _ =>
+              p.raw(n.toString)
+              p.raw("f")
+          }
+        }
       case Lit.Int(l) => p.raw(l.toString)
       case Lit.Long(l) => p.raw(l.toString); p.raw("L")
       case Lit.Null() => p.raw("null")

--- a/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
@@ -8,7 +8,33 @@ trait TreeSyntax { self: Universe =>
 
   private[macros] implicit def treeSyntax[T <: Tree]: Syntax[T] = new Syntax[T] {
     override def render(p: Prettyprinter, x: T): Unit = x match {
-      case Lit.Char(ch) => p.raw("'"); p.raw(ch.toString); p.raw("'")
+      case Term.This(qual) =>
+        render(p, qual.asInstanceOf[T])
+        p.raw(".this")
+      case Term.Apply(fun, args) =>
+        render(p, fun.asInstanceOf[T])
+        p.raw("(")
+        args match {
+          case Nil =>
+          case head :: tail =>
+            render(p, head.asInstanceOf[T])
+            tail.foreach { arg =>
+              p.raw(", ")
+              render(p, arg.asInstanceOf[T])
+            }
+        }
+        p.raw(")")
+      case Term.Select(qual, name) =>
+        render(p, qual.asInstanceOf[T])
+        p.raw(".")
+        p.raw(name.value)
+      case Name.Indeterminate(value) => p.raw(value)
+      case Type.Name(value) => p.raw(value)
+      case Term.Name(value) => p.raw(value)
+      case Lit.Char(ch) =>
+        p.raw("'")
+        p.raw(ch.toString)
+        p.raw("'")
       case Lit.Double(n) =>
         if (java.lang.Double.isNaN(n)) p.raw("Double.NaN")
         else {
@@ -32,12 +58,20 @@ trait TreeSyntax { self: Universe =>
           }
         }
       case Lit.Int(l) => p.raw(l.toString)
-      case Lit.Long(l) => p.raw(l.toString); p.raw("L")
+      case Lit.Long(l) =>
+        p.raw(l.toString)
+        p.raw("L")
       case Lit.Null() => p.raw("null")
-      case Lit.String(str) => p.raw("\""); p.raw(str); p.raw("\"")
-      case Lit.Symbol(sym) => p.raw("'"); p.raw(sym.name)
+      case Lit.String(str) =>
+        p.raw("\"")
+        p.raw(str)
+        p.raw("\"")
+      case Lit.Symbol(sym) =>
+        p.raw("'")
+        p.raw(sym.name)
       case els =>
         println(s"ELS: $els (${els.getClass})")
+        pprint.log(els)
         ???
     }
   }

--- a/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
@@ -6,8 +6,19 @@ import scala.macros.Universe
 
 trait TreeSyntax { self: Universe =>
 
-  private[macros] implicit def treeSyntax[T <: Tree]: Syntax[T] = Syntax { (p, tree) =>
-    // TODO: implement this
-    ???
+  private[macros] implicit def treeSyntax[T <: Tree]: Syntax[T] = new Syntax[T] {
+    override def render(p: Prettyprinter, x: T): Unit = x match {
+      case Lit.Char(ch) => p.raw("'"); p.raw(ch.toString); p.raw("'")
+      case Lit.Double(d) => p.raw(d.toString); p.raw("d")
+      case Lit.Float(f) => p.raw(f.toString); p.raw("f")
+      case Lit.Int(l) => p.raw(l.toString)
+      case Lit.Long(l) => p.raw(l.toString); p.raw("L")
+      case Lit.Null() => p.raw("null")
+      case Lit.String(str) => p.raw("\""); p.raw(str); p.raw("\"")
+      case Lit.Symbol(sym) => p.raw("'"); p.raw(sym.name)
+      case els =>
+        println(s"ELS: $els (${els.getClass})")
+        ???
+    }
   }
 }

--- a/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
@@ -69,9 +69,8 @@ trait TreeSyntax { self: Universe =>
       case Lit.Symbol(sym) =>
         p.raw("'")
         p.raw(sym.name)
-      case els =>
-        println(s"ELS: $els (${els.getClass})")
-        pprint.log(els)
+      case _ =>
+        println(s"NotImplementedYet: $x (${x.getClass})")
         ???
     }
   }

--- a/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
+++ b/core/src/main/scala/scala/macros/internal/trees/TreeSyntax.scala
@@ -11,6 +11,22 @@ trait TreeSyntax { self: Universe =>
       case Term.This(qual) =>
         render(p, qual.asInstanceOf[T])
         p.raw(".this")
+      case Term.ApplyType(fun, targs) =>
+        render(p, fun.asInstanceOf[T])
+        p.raw("[")
+        targs match {
+          case Nil =>
+            sys.error(s"Expected nonempty list for Term.ApplyType $x")
+          case head :: tail =>
+            render(p, head.asInstanceOf[T])
+            tail.foreach { arg =>
+              p.raw(", ")
+              render(p, arg.asInstanceOf[T])
+            }
+        }
+        p.raw("]")
+      case Type.Apply(fun, targs) =>
+        p.raw(x.toString) // TODO(olafur) hack
       case Term.Apply(fun, args) =>
         render(p, fun.asInstanceOf[T])
         p.raw("(")

--- a/core/src/main/scala/scala/macros/trees/Companions.scala
+++ b/core/src/main/scala/scala/macros/trees/Companions.scala
@@ -75,7 +75,7 @@ private[macros] trait Companions { self: Universe =>
     }
 
     trait TermThisCompanion {
-      def apply(qual: Name): Term.Ref
+      def apply(qual: Name): Term
       def unapply(tree: Any): Option[Name]
     }
 

--- a/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/trees/Abstracts.scala
+++ b/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/trees/Abstracts.scala
@@ -95,42 +95,55 @@ trait Abstracts extends scala.macros.trees.Abstracts with Positions { self: Univ
 
     object LitChar extends LitCharCompanion {
       def apply(value: Char): Lit = g.Literal(g.Constant(value))
-      def unapply(gtree: Any): Option[Char] = ???
+      def unapply(gtree: Any): Option[Char] =
+        litUnapply(gtree).collect { case x: Char => x }
     }
 
     object LitInt extends LitIntCompanion {
       def apply(value: Int): Lit = g.Literal(g.Constant(value))
-      def unapply(gtree: Any): Option[Int] = ???
+      def unapply(gtree: Any): Option[Int] =
+        litUnapply(gtree).collect { case x: Int => x }
     }
 
     object LitFloat extends LitFloatCompanion {
       def apply(value: Float): Lit = g.Literal(g.Constant(value))
-      def unapply(gtree: Any): Option[Float] = ???
+      def unapply(gtree: Any): Option[Float] =
+        litUnapply(gtree).collect { case x: Float => x }
     }
 
     object LitLong extends LitLongCompanion {
       def apply(value: Long): Lit = g.Literal(g.Constant(value))
-      def unapply(gtree: Any): Option[Long] = ???
+      def unapply(gtree: Any): Option[Long] =
+        litUnapply(gtree).collect { case x: Long => x }
     }
 
     object LitDouble extends LitDoubleCompanion {
       def apply(value: Double): Lit = g.Literal(g.Constant(value))
-      def unapply(gtree: Any): Option[Double] = ???
+      def unapply(gtree: Any): Option[Double] =
+        litUnapply(gtree).collect { case x: Double => x }
     }
 
     object LitString extends LitStringCompanion {
       def apply(value: String): Lit = g.Literal(g.Constant(value))
-      def unapply(gtree: Any): Option[String] = ???
+      def unapply(gtree: Any): Option[String] =
+        litUnapply(gtree).collect { case s: String => s }
     }
 
     object LitSymbol extends LitSymbolCompanion {
       def apply(value: scala.Symbol): Lit = g.Literal(g.Constant(value))
-      def unapply(gtree: Any): Option[scala.Symbol] = ???
+      lazy val symApply = g.typeOf[scala.Symbol.type].member(g.TermName("apply"))
+      def unapply(gtree: Any): Option[scala.Symbol] = gtree match {
+        case apply @ g.Apply(_, g.Literal(g.Constant(name: String)) :: Nil)
+            if symApply == apply.symbol =>
+          Some(scala.Symbol(name))
+        case _ => None
+      }
     }
 
     object LitNull extends LitNullCompanion {
       def apply(): Lit = g.Literal(g.Constant(null))
-      def unapply(gtree: Any): Boolean = ???
+      def unapply(gtree: Any): Boolean =
+        litUnapply(gtree).contains(null)
     }
 
     object TermThis extends TermThisCompanion {

--- a/plugins/scalac/src/main/scala/scala/macros/internal/plugins/scalac/parser/SyntaxAnalyzer.scala
+++ b/plugins/scalac/src/main/scala/scala/macros/internal/plugins/scalac/parser/SyntaxAnalyzer.scala
@@ -33,7 +33,7 @@ abstract class SyntaxAnalyzer extends NscSyntaxAnalyzer with ReflectToolkit {
 
     override def funDefRest(start: Offset, nameOff: Offset, mods: Modifiers, name: Name): Tree = {
       super.funDefRest(start, nameOff, mods, name) match {
-        case newmacro @ DefDef(mods, _, _, _, _, Block(_, _)) if mods.isMacro =>
+        case newmacro @ DefDef(mods, _, _, _, _, Block(_, _) | Apply(_, _)) if mods.isMacro =>
           if (!hasLibraryDependencyOnScalamacros) MissingLibraryDependencyOnScalamacros(r2p(start))
           copyDefDef(newmacro)(mods = mods.markNewMacro(r2p(start)))
         case other =>

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
@@ -9,22 +9,26 @@ trait Serialize[T] {
 
 object Serialize {
   def apply[T](fn: T => String) = new Serialize[T] { def apply(x: T) = fn(x) }
-  implicit def int: Serialize[Int] = Serialize { x => x.toString }
-  implicit def string: Serialize[String] = Serialize { x => "\"" + x + "\"" }
+  implicit def int: Serialize[Int] = Serialize { x =>
+    x.toString
+  }
+  implicit def string: Serialize[String] = Serialize { x =>
+    "\"" + x + "\""
+  }
 
   implicit def materialize[T]: Serialize[T] = macro {
     val instance = Term.fresh("instance")
     val param = Term.fresh("x")
     val buf = Term.fresh("buf")
     val fieldSerialization = {
-      val serializerss = T.vals.filter(_.isCase).map(f => {
+      val serializerss = T.vals.filter(_.isCase).map { f =>
         val namePart = Lit.String("\"" + f.name.value + "\": ")
         val appendName = q"$buf ++= $namePart"
         val valueRef = q"$param.${Term.Name(f.sym)}"
         val valuePart = q"_root_.scala.Predef.implicitly[Serialize[${f.info}]].apply($valueRef)"
         val appendValue = q"$buf ++= $valuePart"
         List(appendName, appendValue)
-      })
+      }
       val separators = serializerss.map(_ => q"""$buf ++= ", """")
       serializerss.zip(separators).map({ case (ss, s) => ss :+ s }).flatten.dropRight(1)
     }

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
@@ -16,7 +16,7 @@ object Serialize {
     "\"" + x + "\""
   }
 
-  implicit def materialize[T]: Serialize[T] = macro {
+  def materialize[T]: Serialize[T] = macro {
     val instance = Term.fresh("instance")
     val param = Term.fresh("x")
     val buf = Term.fresh("buf")

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/TestMacros.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/TestMacros.scala
@@ -2,8 +2,6 @@ package scala.macros.tests.scaladays
 
 import scala.macros._
 
-import scala.language.experimental.macros
-
 object TestMacros {
   def syntax[T](a: T): String = macro Lit.String(a.syntax)
   def structure[T](a: T): String = macro Lit.String(a.structure)

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/TestMacros.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/TestMacros.scala
@@ -5,7 +5,6 @@ import scala.macros._
 import scala.language.experimental.macros
 
 object TestMacros {
-//  implicit def syntax[T]: Int = macro {
-//    q"22"
-//  }
+  def syntax[T](a: T): String = macro Lit.String(a.syntax)
+  def structure[T](a: T): String = macro Lit.String(a.structure)
 }

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/TestMacros.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/TestMacros.scala
@@ -1,0 +1,11 @@
+package scala.macros.tests.scaladays
+
+import scala.macros._
+
+import scala.language.experimental.macros
+
+object TestMacros {
+//  implicit def syntax[T]: Int = macro {
+//    q"22"
+//  }
+}

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/SerializeSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/SerializeSuite.scala
@@ -5,14 +5,12 @@ import org.junit._
 import org.junit.runner._
 import org.junit.runners._
 import org.junit.Assert._
-import scala.macros.config._
 
 @RunWith(classOf[JUnit4])
 class SerializeSuite {
   @Test
   def simple: Unit = {
     case class C(x: Int, y: String)
-    def serialize[T: Serialize](x: T): String = implicitly[Serialize[T]].apply(x)
-    assertEquals("""{ "x": 40, "y": "2" }""", serialize(C(40, "2")))
+    assertEquals("""{ "x": 40, "y": "2" }""", Serialize.materialize[C](C(40, "2")))
   }
 }

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
@@ -1,0 +1,18 @@
+package scala.macros.tests.scaladays
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class StructureSuite {
+  @Test def structureChar: Unit = assertEquals("Lit.Char('2')", TestMacros.structure('2'))
+  @Test def structureDouble: Unit = assertEquals("Lit.Double(2.0d)", TestMacros.structure(2d))
+  @Test def structureFloat: Unit = assertEquals("Lit.Float(2.0f)", TestMacros.structure(2f))
+  @Test def structureInt: Unit = assertEquals("Lit.Int(2)", TestMacros.structure(2))
+  @Test def structureLong: Unit = assertEquals("Lit.Long(2L)", TestMacros.structure(2L))
+  @Test def structureNull: Unit = assertEquals("Lit.Null()", TestMacros.structure(null))
+  @Test def structureString: Unit = assertEquals("Lit.String(\"2\")", TestMacros.structure("2"))
+  @Test def structureSymbol: Unit = assertEquals("Lit.Symbol('S)", TestMacros.structure('S))
+}

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
@@ -7,12 +7,38 @@ import org.junit.runners.JUnit4
 
 @RunWith(classOf[JUnit4])
 class StructureSuite {
-  @Test def structureChar: Unit = assertEquals("Lit.Char('2')", TestMacros.structure('2'))
-  @Test def structureDouble: Unit = assertEquals("Lit.Double(2.0d)", TestMacros.structure(2d))
-  @Test def structureFloat: Unit = assertEquals("Lit.Float(2.0f)", TestMacros.structure(2f))
-  @Test def structureInt: Unit = assertEquals("Lit.Int(2)", TestMacros.structure(2))
-  @Test def structureLong: Unit = assertEquals("Lit.Long(2L)", TestMacros.structure(2L))
-  @Test def structureNull: Unit = assertEquals("Lit.Null()", TestMacros.structure(null))
-  @Test def structureString: Unit = assertEquals("Lit.String(\"2\")", TestMacros.structure("2"))
-  @Test def structureSymbol: Unit = assertEquals("Lit.Symbol('S)", TestMacros.structure('S))
+  import TestMacros.structure
+
+  @Test def char: Unit = assertEquals("Lit.Char('2')", structure('2'))
+  @Test def double: Unit = assertEquals("Lit.Double(2.0d)", structure(2d))
+  @Test def float: Unit = assertEquals("Lit.Float(2.0f)", structure(2f))
+  @Test def int: Unit = assertEquals("Lit.Int(2)", structure(2))
+  @Test def long: Unit = assertEquals("Lit.Long(2L)", structure(2L))
+  @Test def `null`: Unit = assertEquals("Lit.Null()", structure(null))
+  @Test def string: Unit = assertEquals("Lit.String(\"2\")", structure("2"))
+  @Test def symbol: Unit = assertEquals("Lit.Symbol('S)", structure('S))
+
+  val x = "a"
+  @Test def name: Unit =
+    assertEquals(
+      """Term.Select(Term.This(Name("StructureSuite")), Term.Name("x"))""",
+      structure(x)
+    )
+
+  @Test def apply0: Unit =
+    assertEquals(
+      """Term.Apply(Term.Select(Lit.String("a"), Term.Name("trim")), Nil)""",
+      structure("a".trim)
+    )
+  @Test def apply1: Unit =
+    assertEquals(
+      """Term.Apply(Term.Select(Lit.String("a"), Term.Name("charAt")), List(Lit.Int(0)))""",
+      structure("a".charAt(0))
+    )
+  @Test def apply2: Unit =
+    assertEquals(
+      "Term.Apply(Term.Select(Lit.String(\"a\"), Term.Name(\"substring\")), List(Lit.Int(0), Lit.Int(1)))",
+      structure("a".substring(0, 1))
+    )
+
 }

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
@@ -41,4 +41,5 @@ class StructureSuite {
       structure("a".substring(0, 1))
     )
 
+  // TODO(olafur) Type.Apply
 }

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/StructureSuite.scala
@@ -9,33 +9,33 @@ import org.junit.runners.JUnit4
 class StructureSuite {
   import TestMacros.structure
 
-  @Test def char: Unit = assertEquals("Lit.Char('2')", structure('2'))
-  @Test def double: Unit = assertEquals("Lit.Double(2.0d)", structure(2d))
-  @Test def float: Unit = assertEquals("Lit.Float(2.0f)", structure(2f))
-  @Test def int: Unit = assertEquals("Lit.Int(2)", structure(2))
-  @Test def long: Unit = assertEquals("Lit.Long(2L)", structure(2L))
-  @Test def `null`: Unit = assertEquals("Lit.Null()", structure(null))
-  @Test def string: Unit = assertEquals("Lit.String(\"2\")", structure("2"))
-  @Test def symbol: Unit = assertEquals("Lit.Symbol('S)", structure('S))
+  @Test def char(): Unit = assertEquals("Lit.Char('2')", structure('2'))
+  @Test def double(): Unit = assertEquals("Lit.Double(2.0d)", structure(2d))
+  @Test def float(): Unit = assertEquals("Lit.Float(2.0f)", structure(2f))
+  @Test def int(): Unit = assertEquals("Lit.Int(2)", structure(2))
+  @Test def long(): Unit = assertEquals("Lit.Long(2L)", structure(2L))
+  @Test def `null`(): Unit = assertEquals("Lit.Null()", structure(null))
+  @Test def string(): Unit = assertEquals("Lit.String(\"2\")", structure("2"))
+  @Test def symbol(): Unit = assertEquals("Lit.Symbol('S)", structure('S))
 
   val x = "a"
-  @Test def name: Unit =
+  @Test def name(): Unit =
     assertEquals(
       """Term.Select(Term.This(Name("StructureSuite")), Term.Name("x"))""",
       structure(x)
     )
 
-  @Test def apply0: Unit =
+  @Test def apply0(): Unit =
     assertEquals(
       """Term.Apply(Term.Select(Lit.String("a"), Term.Name("trim")), Nil)""",
       structure("a".trim)
     )
-  @Test def apply1: Unit =
+  @Test def apply1(): Unit =
     assertEquals(
       """Term.Apply(Term.Select(Lit.String("a"), Term.Name("charAt")), List(Lit.Int(0)))""",
       structure("a".charAt(0))
     )
-  @Test def apply2: Unit =
+  @Test def apply2(): Unit =
     assertEquals(
       "Term.Apply(Term.Select(Lit.String(\"a\"), Term.Name(\"substring\")), List(Lit.Int(0), Lit.Int(1)))",
       structure("a".substring(0, 1))

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
@@ -1,0 +1,32 @@
+package scala.macros.tests.scaladays
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class SyntaxSuite {
+  @Test def syntaxChar: Unit = assertEquals("'2'", TestMacros.syntax('2'))
+  @Test def syntaxDouble: Unit = assertEquals("2.0d", TestMacros.syntax(2d))
+  @Test def syntaxFloat: Unit = assertEquals("2.0f", TestMacros.syntax(2f))
+  @Test def syntaxInt: Unit = assertEquals("2", TestMacros.syntax(2))
+  @Test def syntaxLong: Unit = assertEquals("2L", TestMacros.syntax(2L))
+  @Test def syntaxNull: Unit = assertEquals("null", TestMacros.syntax(null))
+  @Test def syntaxString: Unit = assertEquals("\"2\"", TestMacros.syntax("2"))
+  @Test def syntaxSymbol: Unit = assertEquals("'S", TestMacros.syntax('S))
+
+  // special cases
+  @Test def syntaxDoubleNaN: Unit =
+    assertEquals("Double.NaN", TestMacros.syntax(Double.NaN))
+  @Test def syntaxDoublePosInf: Unit =
+    assertEquals("Double.PositiveInfinity", TestMacros.syntax(Double.PositiveInfinity))
+  @Test def syntaxDoubleNegInf: Unit =
+    assertEquals("Double.NegativeInfinity", TestMacros.syntax(Double.NegativeInfinity))
+  @Test def syntaxFloatNaN: Unit =
+    assertEquals("Float.NaN", TestMacros.syntax(Float.NaN))
+  @Test def syntaxFloatPosInf: Unit =
+    assertEquals("Float.PositiveInfinity", TestMacros.syntax(Float.PositiveInfinity))
+  @Test def syntaxFloatNegInf: Unit =
+    assertEquals("Float.NegativeInfinity", TestMacros.syntax(Float.NegativeInfinity))
+}

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
@@ -7,26 +7,38 @@ import org.junit.runners.JUnit4
 
 @RunWith(classOf[JUnit4])
 class SyntaxSuite {
-  @Test def syntaxChar: Unit = assertEquals("'2'", TestMacros.syntax('2'))
-  @Test def syntaxDouble: Unit = assertEquals("2.0d", TestMacros.syntax(2d))
-  @Test def syntaxFloat: Unit = assertEquals("2.0f", TestMacros.syntax(2f))
-  @Test def syntaxInt: Unit = assertEquals("2", TestMacros.syntax(2))
-  @Test def syntaxLong: Unit = assertEquals("2L", TestMacros.syntax(2L))
-  @Test def syntaxNull: Unit = assertEquals("null", TestMacros.syntax(null))
-  @Test def syntaxString: Unit = assertEquals("\"2\"", TestMacros.syntax("2"))
-  @Test def syntaxSymbol: Unit = assertEquals("'S", TestMacros.syntax('S))
+  import TestMacros.syntax
+  @Test def char: Unit = assertEquals("'2'", syntax('2'))
+  @Test def double: Unit = assertEquals("2.0d", syntax(2d))
+  @Test def float: Unit = assertEquals("2.0f", syntax(2f))
+  @Test def int: Unit = assertEquals("2", syntax(2))
+  @Test def long: Unit = assertEquals("2L", syntax(2L))
+  @Test def `null`: Unit = assertEquals("null", syntax(null))
+  @Test def string: Unit = assertEquals("\"2\"", syntax("2"))
+  @Test def symbol: Unit = assertEquals("'S", syntax('S))
 
   // special cases
-  @Test def syntaxDoubleNaN: Unit =
-    assertEquals("Double.NaN", TestMacros.syntax(Double.NaN))
-  @Test def syntaxDoublePosInf: Unit =
-    assertEquals("Double.PositiveInfinity", TestMacros.syntax(Double.PositiveInfinity))
-  @Test def syntaxDoubleNegInf: Unit =
-    assertEquals("Double.NegativeInfinity", TestMacros.syntax(Double.NegativeInfinity))
-  @Test def syntaxFloatNaN: Unit =
-    assertEquals("Float.NaN", TestMacros.syntax(Float.NaN))
-  @Test def syntaxFloatPosInf: Unit =
-    assertEquals("Float.PositiveInfinity", TestMacros.syntax(Float.PositiveInfinity))
-  @Test def syntaxFloatNegInf: Unit =
-    assertEquals("Float.NegativeInfinity", TestMacros.syntax(Float.NegativeInfinity))
+  @Test def doubleNaN: Unit =
+    assertEquals("Double.NaN", syntax(Double.NaN))
+  @Test def doublePosInf: Unit =
+    assertEquals("Double.PositiveInfinity", syntax(Double.PositiveInfinity))
+  @Test def doubleNegInf: Unit =
+    assertEquals("Double.NegativeInfinity", syntax(Double.NegativeInfinity))
+  @Test def floatNaN: Unit =
+    assertEquals("Float.NaN", syntax(Float.NaN))
+  @Test def floatPosInf: Unit =
+    assertEquals("Float.PositiveInfinity", syntax(Float.PositiveInfinity))
+  @Test def floatNegInf: Unit =
+    assertEquals("Float.NegativeInfinity", syntax(Float.NegativeInfinity))
+
+  val x = "a"
+  @Test def name: Unit = assertEquals("SyntaxSuite.this.x", syntax(x))
+
+  @Test def apply0: Unit =
+    assertEquals("\"a\".trim()", syntax("a".trim))
+  @Test def apply1: Unit =
+    assertEquals("\"a\".charAt(0)", syntax("a".charAt(0)))
+  @Test def apply2: Unit =
+    assertEquals("\"a\".substring(0, 1)", syntax("a".substring(0, 1)))
+
 }

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
@@ -40,6 +40,8 @@ class SyntaxSuite {
     assertEquals("\"a\".charAt(0)", syntax("a".charAt(0)))
   @Test def apply2(): Unit =
     assertEquals("\"a\".substring(0, 1)", syntax("a".substring(0, 1)))
+  @Test def applySymbol(): Unit =
+    assertEquals("scala.Symbol.apply(\"S\")", syntax(scala.Symbol.apply("S")))
 
   def add(a: Int)(b: Int): Int = a + b
   @Test def applyCurry(): Unit =

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
@@ -8,37 +8,37 @@ import org.junit.runners.JUnit4
 @RunWith(classOf[JUnit4])
 class SyntaxSuite {
   import TestMacros.syntax
-  @Test def char: Unit = assertEquals("'2'", syntax('2'))
-  @Test def double: Unit = assertEquals("2.0d", syntax(2d))
-  @Test def float: Unit = assertEquals("2.0f", syntax(2f))
-  @Test def int: Unit = assertEquals("2", syntax(2))
-  @Test def long: Unit = assertEquals("2L", syntax(2L))
-  @Test def `null`: Unit = assertEquals("null", syntax(null))
-  @Test def string: Unit = assertEquals("\"2\"", syntax("2"))
-  @Test def symbol: Unit = assertEquals("'S", syntax('S))
+  @Test def char(): Unit = assertEquals("'2'", syntax('2'))
+  @Test def double(): Unit = assertEquals("2.0d", syntax(2d))
+  @Test def float(): Unit = assertEquals("2.0f", syntax(2f))
+  @Test def int(): Unit = assertEquals("2", syntax(2))
+  @Test def long(): Unit = assertEquals("2L", syntax(2L))
+  @Test def `null`(): Unit = assertEquals("null", syntax(null))
+  @Test def string(): Unit = assertEquals("\"2\"", syntax("2"))
+  @Test def symbol(): Unit = assertEquals("'S", syntax('S))
 
   // special cases
-  @Test def doubleNaN: Unit =
+  @Test def doubleNaN(): Unit =
     assertEquals("Double.NaN", syntax(Double.NaN))
-  @Test def doublePosInf: Unit =
+  @Test def doublePosInf(): Unit =
     assertEquals("Double.PositiveInfinity", syntax(Double.PositiveInfinity))
-  @Test def doubleNegInf: Unit =
+  @Test def doubleNegInf(): Unit =
     assertEquals("Double.NegativeInfinity", syntax(Double.NegativeInfinity))
-  @Test def floatNaN: Unit =
+  @Test def floatNaN(): Unit =
     assertEquals("Float.NaN", syntax(Float.NaN))
-  @Test def floatPosInf: Unit =
+  @Test def floatPosInf(): Unit =
     assertEquals("Float.PositiveInfinity", syntax(Float.PositiveInfinity))
-  @Test def floatNegInf: Unit =
+  @Test def floatNegInf(): Unit =
     assertEquals("Float.NegativeInfinity", syntax(Float.NegativeInfinity))
 
   val x = "a"
-  @Test def name: Unit = assertEquals("SyntaxSuite.this.x", syntax(x))
+  @Test def name(): Unit = assertEquals("SyntaxSuite.this.x", syntax(x))
 
-  @Test def apply0: Unit =
+  @Test def apply0(): Unit =
     assertEquals("\"a\".trim()", syntax("a".trim))
-  @Test def apply1: Unit =
+  @Test def apply1(): Unit =
     assertEquals("\"a\".charAt(0)", syntax("a".charAt(0)))
-  @Test def apply2: Unit =
+  @Test def apply2(): Unit =
     assertEquals("\"a\".substring(0, 1)", syntax("a".substring(0, 1)))
 
 }

--- a/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
+++ b/tests/macros/src/test/scala/scala/macros/tests/scaladays/SyntaxSuite.scala
@@ -41,4 +41,16 @@ class SyntaxSuite {
   @Test def apply2(): Unit =
     assertEquals("\"a\".substring(0, 1)", syntax("a".substring(0, 1)))
 
+  def add(a: Int)(b: Int): Int = a + b
+  @Test def applyCurry(): Unit =
+    assertEquals("SyntaxSuite.this.add(1)(2)", syntax(add(1)(2)))
+
+  def tpe[T](e: T) = e
+  @Test def typeApply(): Unit =
+    assertEquals("SyntaxSuite.this.tpe[Int](2)", syntax(tpe(2)))
+  val lst = List(1)
+  @Test def typeApplyHK(): Unit = {
+    assertEquals("SyntaxSuite.this.tpe[List[Int]](SyntaxSuite.this.lst)", syntax(tpe(lst)))
+  }
+
 }


### PR DESCRIPTION
I used this as a warming up exercise to become familiar with the codebase and how to unapply/apply abstract syntax. It doesn't feel too different from the converter-based approach in scalameta/paradise.

The pretty-printers are implemented in a very raw way, everything inlined with a lot of duplicated code. I wanted to get the basic tests passing first before trying to abstract over the boilerplate. However, I don't expect TreeSyntax or TreeStructure will become much more complicated to merit sophisticated pretty-printing combinators.

The newly added structure/syntax tests are a good foundation to test the portability of very simple macros. Next up is to get some def macros working in Dotty 😎 