### PR TITLE
Simplify trees

### DIFF
--- a/core/src/main/scala/scala/macros/core/Universe.scala
+++ b/core/src/main/scala/scala/macros/core/Universe.scala
@@ -7,7 +7,7 @@ trait Universe {
   // Trees
   // =========
   type Tree
-  type Stat
+  type Defn
   type Type
   type Term
   type Name
@@ -21,7 +21,6 @@ trait Universe {
   type TypeBounds
   type TypeParam
   type Pat
-  type Defn
 
   def fresh(prefix: String): String
 
@@ -39,7 +38,7 @@ trait Universe {
   def TermApply(fun: Term, args: List[Term]): Term
   def TermApplyUnapply(arg: Any): Option[(Term, List[Term])]
   def TermApplyType(fun: Term, args: List[Type]): Term
-  def TermBlock(stats: List[Stat]): Term
+  def TermBlock(stats: List[Tree]): Term
   def LitString(value: String): Lit
   def LitInt(value: Int): Lit
   def Self(name: Name, decltpe: Option[Type]): Self
@@ -68,7 +67,7 @@ trait Universe {
       name: TermName,
       init: List[Init],
       self: Self,
-      stats: List[Stat]
+      stats: List[Tree]
   ): Defn
   def DefnVal(mods: List[Mod], name: TermName, decltpe: Option[Type], rhs: Term): Defn
   def DefnDef(

--- a/core/src/main/scala/scala/macros/core/Universe.scala
+++ b/core/src/main/scala/scala/macros/core/Universe.scala
@@ -47,7 +47,7 @@ trait Universe {
   def LitString(value: String): Lit
   def LitInt(value: Int): Lit
   def Self(name: Name, decltpe: Option[Type]): Self
-  def Init(tpe: Type, name: Name, argss: List[List[Term]]): Init
+  def Init(tpe: Type, argss: List[List[Term]]): Init
   def TermNew(init: Init): Term
   def TermParam(
       mods: List[Mod],

--- a/core/src/main/scala/scala/macros/core/Universe.scala
+++ b/core/src/main/scala/scala/macros/core/Universe.scala
@@ -7,20 +7,25 @@ trait Universe {
   // Trees
   // =========
   type Tree
-  type Defn
-  type Type
+
   type Term
-  type Name
   type TermName
   type TermParam
+
+  type Defn
+
+  type Type
+  type TypeName
+  type TypeParam
+  type TypeBounds
+
+  type Name
+
+  type Pat
   type Lit
   type Mod
   type Self
   type Init
-  type TypeName
-  type TypeBounds
-  type TypeParam
-  type Pat
 
   def fresh(prefix: String): String
 

--- a/core/src/main/scala/scala/macros/core/Universe.scala
+++ b/core/src/main/scala/scala/macros/core/Universe.scala
@@ -11,7 +11,6 @@ trait Universe {
   type Type
   type Term
   type Name
-  type TermRef // NOTE(olafur) subject for removal
   type TermName // NOTE(olafur) subject for removal
   type TermParam
   type Lit
@@ -38,7 +37,7 @@ trait Universe {
   def TermNameSymbol(symbol: Symbol): TermName
   def TermNameUnapply(arg: Any): Option[String]
   def TermSelect(qual: Term, name: TermName): Term
-  def TermSelectUnapply(arg: Any): Option[(TermRef, TermName)]
+  def TermSelectUnapply(arg: Any): Option[(Term, TermName)]
   def TermApply(fun: Term, args: List[Term]): Term
   def TermApplyUnapply(arg: Any): Option[(Term, List[Term])]
   def TermApplyType(fun: Term, args: List[Type]): Term
@@ -57,7 +56,7 @@ trait Universe {
   ): TermParam
   def TypeName(value: String): TypeName
   def TypeNameSymbol(sym: Symbol): TypeName
-  def TypeSelect(qual: TermRef, name: TypeName): Type
+  def TypeSelect(qual: Term, name: TypeName): Type
   def TypeApply(tpe: Term, args: List[Type]): Type
   def TypeParam(
       mods: List[Mod],

--- a/core/src/main/scala/scala/macros/core/Universe.scala
+++ b/core/src/main/scala/scala/macros/core/Universe.scala
@@ -17,7 +17,6 @@ trait Universe {
   type Mod
   type Self
   type Init
-  type Template
   type TypeName
   type TypeBounds
   type TypeParam
@@ -45,7 +44,6 @@ trait Universe {
   def LitInt(value: Int): Lit
   def Self(name: Name, decltpe: Option[Type]): Self
   def Init(tpe: Type, name: Name, argss: List[List[Term]]): Init
-  def Template(inits: List[Init], self: Self, stats: List[Stat]): Template
   def TermNew(init: Init): Term
   def TermParam(
       mods: List[Mod],
@@ -65,7 +63,13 @@ trait Universe {
       vbounds: List[Type],
       cbounds: List[Type]
   ): TypeParam
-  def DefnObject(mods: List[Mod], name: TermName, templ: Template): Defn
+  def DefnObject(
+      mods: List[Mod],
+      name: TermName,
+      init: List[Init],
+      self: Self,
+      stats: List[Stat]
+  ): Defn
   def DefnVal(mods: List[Mod], name: TermName, decltpe: Option[Type], rhs: Term): Defn
   def DefnDef(
       mods: List[Mod],

--- a/core/src/main/scala/scala/macros/core/Universe.scala
+++ b/core/src/main/scala/scala/macros/core/Universe.scala
@@ -11,7 +11,7 @@ trait Universe {
   type Type
   type Term
   type Name
-  type TermName // NOTE(olafur) subject for removal
+  type TermName
   type TermParam
   type Lit
   type Mod
@@ -22,7 +22,6 @@ trait Universe {
   type TypeBounds
   type TypeParam
   type Pat
-  type PatVar // NOTE(olafur) subject for removal
   type Defn
 
   def fresh(prefix: String): String
@@ -67,7 +66,7 @@ trait Universe {
       cbounds: List[Type]
   ): TypeParam
   def DefnObject(mods: List[Mod], name: TermName, templ: Template): Defn
-  def DefnVal(mods: List[Mod], pats: List[Pat], decltpe: Option[Type], rhs: Term): Defn
+  def DefnVal(mods: List[Mod], name: TermName, decltpe: Option[Type], rhs: Term): Defn
   def DefnDef(
       mods: List[Mod],
       name: TermName,
@@ -76,7 +75,6 @@ trait Universe {
       decltpe: Option[Type],
       body: Term
   ): Defn
-  def PatVar(name: TermName): PatVar
 
   // =========
   // Semantic

--- a/core/src/main/scala/scala/macros/package.scala
+++ b/core/src/main/scala/scala/macros/package.scala
@@ -153,8 +153,8 @@ package object macros {
   }
   type Init
   object Init {
-    def apply(tpe: Type, name: Name, argss: List[List[Term]]): Init =
-      !universe.Init(!tpe, !name, !argss)
+    def apply(tpe: Type, argss: List[List[Term]]): Init =
+      !universe.Init(!tpe, !argss)
   }
   type Mod
   type Defn <: Stat

--- a/core/src/main/scala/scala/macros/package.scala
+++ b/core/src/main/scala/scala/macros/package.scala
@@ -161,14 +161,6 @@ package object macros {
     def apply(tpe: Type, name: Name, argss: List[List[Term]]): Init =
       !universe.Init(!tpe, !name, !argss)
   }
-  type Pat
-  object Pat {
-    type Var <: Pat
-    object Var {
-      def apply(name: Term.Name): Pat.Var =
-        !universe.PatVar(!name)
-    }
-  }
   type Mod
   type Defn <: Stat
   object Defn {
@@ -176,11 +168,11 @@ package object macros {
     object Val {
       def apply(
           mods: List[Mod],
-          pats: List[Pat],
+          name: Term.Name,
           decltpe: Option[Type],
           rhs: Term
       ): Defn.Val =
-        !universe.DefnVal(!mods, !pats, !decltpe, !rhs)
+        !universe.DefnVal(!mods, !name, !decltpe, !rhs)
     }
     type Def <: Defn
     object Def {

--- a/core/src/main/scala/scala/macros/package.scala
+++ b/core/src/main/scala/scala/macros/package.scala
@@ -102,11 +102,6 @@ package object macros {
         !universe.TermParam(!mods, !name, !decltpe, !default)
     }
   }
-  type Template
-  object Template {
-    def apply(inits: List[Init], self: Self, stats: List[Stat]): Template =
-      !universe.Template(!inits, !self, !stats)
-  }
   type Lit <: Term
   object Lit {
     type String <: Lit
@@ -191,9 +186,11 @@ package object macros {
       def apply(
           mods: List[Mod],
           name: Term.Name,
-          templ: Template
+          init: List[Init],
+          self: Self,
+          stats: List[Stat]
       ): Defn.Object =
-        !universe.DefnObject(!mods, !name, !templ)
+        !universe.DefnObject(!mods, !name, !init, !self, !stats)
     }
   }
 }

--- a/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
+++ b/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
@@ -22,7 +22,6 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
   type Type = untpd.Tree
   type Term = untpd.Tree
   type Name = untpd.Tree
-  type TermRef = untpd.Tree
   type TermName = untpd.Tree
   type Lit = untpd.Tree
   type Mod
@@ -91,7 +90,7 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
     case ident: untpd.Ident =>
       untpd.Select(qual, ident.name).autoPos
   }
-  def TermSelectUnapply(arg: Any): Option[(TermRef, TermName)] = arg match {
+  def TermSelectUnapply(arg: Any): Option[(Term, TermName)] = arg match {
     case untpd.Select(t, name) if name.isTermName =>
       Some((t, untpd.Ident(name)))
     case _ => None
@@ -159,7 +158,7 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
   def TypeNameSymbol(sym: Symbol): TypeName =
     tpd.ref(sym).asInstanceOf[TypeName].autoPos
 
-  def TypeSelect(qual: TermRef, name: TypeName): Type =
+  def TypeSelect(qual: Term, name: TypeName): Type =
     untpd.Select(qual, name.asInstanceOf[untpd.Ident].name.asTypeName)
 
   def TypeApply(tpe: Term, args: List[Type]): Type =

--- a/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
+++ b/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
@@ -36,7 +36,6 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
   type TypeParam = untpd.TypeDef
 
   type Pat
-  type PatVar = untpd.Tree
 
   // =========
   // Utilities
@@ -175,19 +174,13 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
 
   def DefnVal(
       mods: List[Mod],
-      pats: List[Pat],
+      name: TermName,
       decltpe: Option[Type],
       rhs: Term
   ): Defn = {
-    val name = pats match {
-      case untpd.Ident(name) :: Nil =>
-        name.asTermName
-      case els => sys.error(els.toString())
-    }
-
     untpd
       .ValDef(
-        name,
+        name.asInstanceOf[untpd.Ident].name.asTermName,
         decltpe.getOrElse(untpd.TypeTree()),
         rhs
       )
@@ -222,8 +215,6 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
         templ
       )
       .autoPos
-
-  def PatVar(name: TermName): PatVar = name
 
   // =========
   // Semantic

--- a/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
+++ b/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
@@ -116,7 +116,7 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
       .ValDef(name.asInstanceOf[untpd.Ident].name.asTermName, decltpe.getOrElse(untpd.TypeTree()), untpd.EmptyTree)
       .autoPos
 
-  def Init(tpe: Type, name: Name, argss: List[List[Term]]): Init =
+  def Init(tpe: Type, argss: List[List[Term]]): Init =
     argss.foldLeft(tpe)(untpd.Apply)
 
   def Template(

--- a/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
+++ b/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
@@ -207,14 +207,18 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
   def DefnObject(
       mods: List[Mod],
       name: TermName,
-      templ: Template
-  ): Defn =
+      init: List[Init],
+      self: Self,
+      stats: List[Stat]
+  ): Defn = {
+    val templ = Template(init, self, stats)
     untpd
       .ModuleDef(
         name.asInstanceOf[untpd.Ident].name.asTermName,
         templ
       )
       .autoPos
+  }
 
   // =========
   // Semantic

--- a/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
+++ b/engines/dotc/src/main/scala/scala/macros/internal/engines/dotc/DottyUniverse.scala
@@ -18,7 +18,6 @@ import Symbols.NoSymbol
 case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macros.core.Universe {
 
   type Tree = untpd.Tree
-  type Stat = untpd.Tree
   type Type = untpd.Tree
   type Term = untpd.Tree
   type Name = untpd.Tree
@@ -104,7 +103,7 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
   def TermApplyType(fun: Term, targs: List[Type]): Term =
     untpd.TypeApply(fun, targs).autoPos
 
-  def TermBlock(stats: List[Stat]): Term = stats match {
+  def TermBlock(stats: List[Tree]): Term = stats match {
     case Nil => untpd.Block(stats, untpd.EmptyTree)
     case _ => untpd.Block(stats.init, stats.last)
   }
@@ -123,7 +122,7 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
   def Template(
       inits: List[Init],
       self: Self,
-      stats: List[Stat]
+      stats: List[Tree]
   ): Template = {
     val constr = untpd.DefDef(nme.CONSTRUCTOR, Nil, Nil, untpd.TypeTree(), untpd.EmptyTree)
     untpd.Template(constr, inits, untpd.EmptyValDef, stats)
@@ -209,7 +208,7 @@ case class DottyUniverse(prefix: untpd.Tree)(implicit ctx: Context) extends macr
       name: TermName,
       init: List[Init],
       self: Self,
-      stats: List[Stat]
+      stats: List[Tree]
   ): Defn = {
     val templ = Template(init, self, stats)
     untpd

--- a/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
+++ b/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
@@ -153,7 +153,6 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
   override def Name(value: String): Name =
     if (value.isEmpty) c.NameAnonymous()
     else c.NameIndeterminate(value)
-  type Term = g.Tree
 
   override type TermName = c.TermName
   override def TermName(value: String): TermName =
@@ -227,9 +226,6 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
     g.AppliedTypeTree(tpe, targs)
 
   type Pat = g.Tree
-  type PatVar = g.Bind
-  override def PatVar(name: c.TermName): PatVar =
-    g.Bind(name.toGTermName, g.Ident(g.nme.WILDCARD))
 
   // =====
   // Lit
@@ -244,20 +240,11 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
   override type Defn = g.Tree
   override def DefnVal(
       mods: List[Mod],
-      pats: List[Pat],
+      name: TermName,
       decltpe: Option[Type],
       rhs: Term
   ): Defn = {
-    pats match {
-      case List(name @ g.Ident(_: g.TermName)) =>
-        val cname: TermName = name.toTermName
-        DefnVal(mods, List(PatVar(cname).setPos(name.pos)), decltpe, rhs)
-      case List(bind: g.Bind) =>
-        val name = bind.toTermName
-        g.ValDef(mods.toGModifiers, name.toGTermName, decltpe.getOrElse(g.TypeTree()), rhs)
-      case _ =>
-        ???
-    }
+    g.ValDef(mods.toGModifiers, name.toGTermName, decltpe.getOrElse(g.TypeTree()), rhs)
   }
   override def DefnDef(
       mods: List[Mod],

--- a/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
+++ b/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
@@ -153,7 +153,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
   override def Name(value: String): Name =
     if (value.isEmpty) c.NameAnonymous()
     else c.NameIndeterminate(value)
-  type TermRef = g.Tree
+  type Term = g.Tree
 
   override type TermName = c.TermName
   override def TermName(value: String): TermName =
@@ -167,7 +167,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
 
   override def TermSelect(qual: Term, name: TermName): Term =
     g.Select(qual, name.toGTermName)
-  override def TermSelectUnapply(arg: Any): Option[(TermRef, TermName)] = arg match {
+  override def TermSelectUnapply(arg: Any): Option[(Term, TermName)] = arg match {
     case g.Select(qual, name) => Some(qual -> new c.TermName(name.decoded))
     case _ => None
   }
@@ -221,7 +221,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
   override def TypeNameSymbol(sym: Symbol): TypeName =
     TypeName(sym.name.decoded).setSymbol(sym)
 
-  override def TypeSelect(qual: TermRef, name: TypeName): Type =
+  override def TypeSelect(qual: Term, name: TypeName): Type =
     g.Select(qual, name.toGTypeName)
   override def TypeApply(tpe: Type, targs: List[Type]): Type =
     g.AppliedTypeTree(tpe, targs)
@@ -461,7 +461,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
 
     case class EnumeratorGuard(cond: Term) extends Enumerator
 
-    case class Importer(ref: TermRef, importees: List[Importee]) extends g.Tree
+    case class Importer(ref: Term, importees: List[Importee]) extends g.Tree
 
     sealed trait Importee extends g.RefTree
 

--- a/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
+++ b/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
@@ -120,7 +120,6 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
 
   def fresh(prefix: String): String = g.freshTermName(prefix)(g.globalFreshNameCreator).toString
 
-  override type Stat = g.Tree
   implicit class XtensionStats(stats: List[g.Tree]) {
     // NOTE(xeno-by): The methods below are supposed to take care of statement-level desugaring/resugaring.
     // For more information, see this code from the early days of scalahost:
@@ -192,7 +191,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
     }
   }
 
-  override def TermBlock(stats: List[Stat]): Term =
+  override def TermBlock(stats: List[Tree]): Term =
     g.gen.mkBlock(stats.toGStats)
 
   override type TermParam = g.ValDef
@@ -263,7 +262,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
       name: TermName,
       init: List[Init],
       self: Self,
-      stats: List[Stat]
+      stats: List[Tree]
   ): Defn = {
     val templ = Template(init, self, stats)
     g.ModuleDef(mods.toGModifiers, name.toGTermName, templ.toGTemplate(g.Modifiers(), Nil))
@@ -285,7 +284,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
   def Template(
       inits: List[Init],
       self: Self,
-      stats: List[Stat]
+      stats: List[Tree]
   ): Template =
     c.Template(Nil, inits, self, stats)
   override type Init = c.Init
@@ -409,7 +408,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
       def name: g.Name = mname.name
     }
 
-    case class Template(early: List[Stat], inits: List[Init], self: Self, stats: List[Stat])
+    case class Template(early: List[Tree], inits: List[Init], self: Self, stats: List[Tree])
         extends g.Tree
 
     sealed trait Mod extends g.Tree

--- a/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
+++ b/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
@@ -288,8 +288,8 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
   ): Template =
     c.Template(Nil, inits, self, stats)
   override type Init = c.Init
-  override def Init(tpe: g.Tree, name: c.Name, argss: List[List[g.Tree]]): c.Init =
-    c.Init(tpe, name, argss)
+  override def Init(tpe: g.Tree, argss: List[List[g.Tree]]): c.Init =
+    c.Init(tpe, c.NameAnonymous(), argss)
   override type Self = c.Self
   override def Self(name: Name, decltpe: Option[Type]): Self =
     c.Self(name, decltpe)

--- a/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
+++ b/engines/scalac/src/main/scala/scala/macros/internal/engines/scalac/ScalacUniverse.scala
@@ -261,14 +261,18 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
   override def DefnObject(
       mods: List[Mod],
       name: TermName,
-      templ: Template
-  ): Defn =
+      init: List[Init],
+      self: Self,
+      stats: List[Stat]
+  ): Defn = {
+    val templ = Template(init, self, stats)
     g.ModuleDef(mods.toGModifiers, name.toGTermName, templ.toGTemplate(g.Modifiers(), Nil))
+  }
 
   // ========
   // Template
   // ========
-  override type Template = c.Template
+  type Template = c.Template
   implicit class XtensionTemplate(tree: Template) {
     def toGTemplate(gctorMods: g.Modifiers, gctorParamss: List[List[g.ValDef]]): g.Template = {
       val gearly = tree.early.toGStats
@@ -278,7 +282,7 @@ case class ScalacUniverse(ctx: Context) extends macros.core.Universe with Flags 
       g.gen.mkTemplate(gparents, gself, gctorMods, gctorParamss, gstats).setPos(tree.pos)
     }
   }
-  override def Template(
+  def Template(
       inits: List[Init],
       self: Self,
       stats: List[Stat]

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
@@ -66,23 +66,21 @@ object Serialize {
     val defnObject: Stat = Defn.Object(
       List(),
       instance,
-      Template(
-        List(Init(Type.Apply(Type.Name("Serialize"), List(T)), Name(""), Nil)),
-        Self(Name(""), None),
-        List(
-          Defn.Def(
-            Nil,
-            Term.Name("apply"),
-            Nil,
-            List(List(Term.Param.apply(Nil, param, Some(T), None))),
-            Some(
-              Type.Select(
-                Term.Name("_root_").select("java").select("lang"),
-                Type.Name("String")
-              )
-            ),
-            Term.Block(stats.result())
-          )
+      List(Init(Type.Apply(Type.Name("Serialize"), List(T)), Name(""), Nil)),
+      Self(Name(""), None),
+      List(
+        Defn.Def(
+          Nil,
+          Term.Name("apply"),
+          Nil,
+          List(List(Term.Param.apply(Nil, param, Some(T), None))),
+          Some(
+            Type.Select(
+              Term.Name("_root_").select("java").select("lang"),
+              Type.Name("String")
+            )
+          ),
+          Term.Block(stats.result())
         )
       )
     )

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
@@ -46,7 +46,7 @@ object Serialize {
     var stats = List.newBuilder[Stat]
     stats += Defn.Val(
       Nil,
-      List(Pat.Var(buf)),
+      buf,
       None,
       Term.New(
         Init(

--- a/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
+++ b/tests/macros/src/main/scala/scala/macros/tests/scaladays/Serialize.scala
@@ -54,7 +54,6 @@ object Serialize {
             Term.Name("_root_").select("scala"),
             Type.Name("StringBuilder")
           ),
-          Name(""),
           Nil
         )
       )
@@ -66,7 +65,7 @@ object Serialize {
     val defnObject: Stat = Defn.Object(
       List(),
       instance,
-      List(Init(Type.Apply(Type.Name("Serialize"), List(T)), Name(""), Nil)),
+      List(Init(Type.Apply(Type.Name("Serialize"), List(T)),  Nil)),
       Self(Name(""), None),
       List(
         Defn.Def(


### PR DESCRIPTION
Removes Stat, Template, Pat.Var, Ident.name. 

- Fix #22
- Fix #20 

I tried to remove TermName/Name  as per #23 but wasn't happy with the result, it forced refactorings like

```scala
val tmpName: String = Term.fresh("tmp")
val tmp = Term.Ident(tmpName)
val bind = Defn.Val(Nil, tmpName, None, rhs)
Term.Block(
 bind ::
  tmp ::
  Nil
)
````
